### PR TITLE
update SQLmanager's duplicate problem that occurs when several execute

### DIFF
--- a/src/SqlManager.java
+++ b/src/SqlManager.java
@@ -81,7 +81,8 @@ public class SqlManager {
 			Statement st = conn.createStatement();
 			ResultSet rs;
 			
-			String query = "insert into Market values ('"+t.marketName+"', '"+t.marketRate+"', '"+t.city+"')";
+			String query = "insert into Market values ('"+t.marketName+"', '"+t.marketRate+"', '"+t.city+"')"
+					+ "on conflict (marketName) do nothing";
 			int ret = st.executeUpdate(query);
 		}
 		
@@ -108,7 +109,8 @@ public class SqlManager {
 			Statement st = conn.createStatement();
 			ResultSet rs;
 			
-			String query = "insert into Item values ('"+t.stKind+"', '"+t.stItem+"', '"+t.stItemCode+"')";
+			String query = "insert into Item values ('"+t.stKind+"', '"+t.stItem+"', '"+t.stItemCode+"')"
+					+ "on conflict (stKind) do nothing";
 			int ret = st.executeUpdate(query);
 		}
 		
@@ -122,7 +124,8 @@ public class SqlManager {
 			ResultSet rs;
 			
 			String query = "insert into Sell values ('"+t.stKind+"', '"+t.marketName+"', '"+t.itemRate+"', '"+
-					t.month+"', '"+t.unit+"', '"+t.monAvgPrice+"')";
+					t.month+"', '"+t.unit+"', '"+t.monAvgPrice+"')"
+							+ "on conflict (stkind, marketName, month) do nothing";
 			int ret = st.executeUpdate(query);
 		}
 		
@@ -209,3 +212,4 @@ public class SqlManager {
         System.out.print("\nExit SQL.");
 	}
 }
+


### PR DESCRIPTION
컴파일을 여러번 할 때 table에 이미 튜플들이 들어있는 경우 primary key 중복 문제로 SQL exception이 발생하는 문제를 발견했습니다
이를 SQLmanager의 insert 문에서 "on conflict ("Primary Key들") do nothing" 을 추가하여 해결해봤습니다